### PR TITLE
Leer codigos de estado

### DIFF
--- a/FrontEnd/src/components/app.js
+++ b/FrontEnd/src/components/app.js
@@ -51,9 +51,14 @@ class App extends Component {
         {
             axios.get(ROOT_URL + "/imagenes/" + cri + "/" + this.state.cant)
                 .then(response => {
+                if (response.status === 200){
                     this.setState({
                         imagenes: response.data
                     });
+                }
+                else{
+                    // Mensaje de error
+                }
                 })
         }
     }
@@ -62,14 +67,21 @@ class App extends Component {
 
         axios.get(ROOT_URL + "/imagenes/0/"+10)
             .then(response => {
+            if (response.status === 200){
                 this.setState({
                     imagenes: response.data,
                 }, function() {
                     console.log(response.data);
                 })
             });
+            }
+            else{
+                // Mensaje de error
+            }
     }
 
+    // y asi con los demas metodos que involucren una petición REST
+                  
     moverALaDerecha() {
         this.setState({
             x: this.state.x + 1


### PR DESCRIPTION
El uso de códigos de estado puede ayudar saber que está respondiendo el servidor antes de intentar hacer algo, esto con el fin de evitar null pointers u otros tipo de errores que tengan que ver con datos vacíos o inválidos, esto también con el ánimo de mejorar la usabilidad y poder mostrarle al usuario un mensaje en caso de que algo salgo mal.